### PR TITLE
Remove hc 9

### DIFF
--- a/app/src/androidTest/java/ch/epfl/sdp/blindwar/login/SplashScreenActivityTest.kt
+++ b/app/src/androidTest/java/ch/epfl/sdp/blindwar/login/SplashScreenActivityTest.kt
@@ -41,6 +41,8 @@ class SplashScreenActivityTest : TestCase() {
     @Test
     fun testNewUser() {
         FirebaseAuth.getInstance().signOut()
+        while (FirebaseAuth.getInstance().currentUser != null){
+        }
         clickOn(R.id.Btn_email)
     }
 }

--- a/app/src/main/java/ch/epfl/sdp/blindwar/data/music/metadata/MusicMetadata.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindwar/data/music/metadata/MusicMetadata.kt
@@ -14,6 +14,14 @@ open class MusicMetadata(
         return artist
     }
 
+    override fun getLevel(): String {
+        return ""
+    }
+
+    override fun getGenre(): String {
+        return ""
+    }
+
     override fun getCover(): String {
         return imageUrl
     }

--- a/app/src/main/java/ch/epfl/sdp/blindwar/game/model/Displayable.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindwar/game/model/Displayable.kt
@@ -8,6 +8,10 @@ interface Displayable {
 
     fun getAuthor(): String
 
+    fun getLevel(): String
+
+    fun getGenre(): String
+
     fun getCover(): String
 
     fun getPreviewUrl(): String

--- a/app/src/main/java/ch/epfl/sdp/blindwar/game/model/LocalPlaylist.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindwar/game/model/LocalPlaylist.kt
@@ -10,5 +10,5 @@ class LocalPlaylist(
     override val songs: List<ResourceMusicMetadata> = emptyList(), // list of playlist's songs metadata
     imageUrl: String = "", // playlist cover
     previewUrl: String = "", // preview song url
-    difficulty: Difficulty = Difficulty.EASY
+    difficulty: Difficulty? = null
 ) : Playlist(pid, name, author, genres, songs, imageUrl, previewUrl, difficulty)

--- a/app/src/main/java/ch/epfl/sdp/blindwar/game/model/OnlinePlaylist.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindwar/game/model/OnlinePlaylist.kt
@@ -10,7 +10,7 @@ class OnlinePlaylist(
     override val songs: List<URIMusicMetadata> = emptyList(), // list of playlist's songs metadata
     imageUrl: String = "", // playlist cover
     previewUrl: String = "", // preview song url
-    difficulty: Difficulty = Difficulty.EASY
+    difficulty: Difficulty? = null
 ) : Playlist(uid, name, author, genres, songs, imageUrl, previewUrl, difficulty)
 
 

--- a/app/src/main/java/ch/epfl/sdp/blindwar/game/model/Playlist.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindwar/game/model/Playlist.kt
@@ -25,7 +25,12 @@ open class Playlist(
     }
 
     override fun getGenre(): String {
-        return genres.elementAt(0).toString()
+        return if(genres.isNotEmpty()) {
+            genres.elementAt(0).toString()
+        } else {
+            ""
+        }
+
     }
 
     override fun getCover(): String {

--- a/app/src/main/java/ch/epfl/sdp/blindwar/game/model/Playlist.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindwar/game/model/Playlist.kt
@@ -10,7 +10,7 @@ open class Playlist(
     open val songs: List<MusicMetadata> = emptyList(), // list of playlist's songs metadata
     val imageUrl: String = "", // playlist cover
     private val previewUrl: String = "", // preview song url
-    val difficulty: Difficulty = Difficulty.EASY
+    val difficulty: Difficulty? = null
 ) : Displayable {
     override fun getName(): String {
         return name
@@ -18,6 +18,14 @@ open class Playlist(
 
     override fun getAuthor(): String {
         return author
+    }
+
+    override fun getLevel(): String {
+        return difficulty.toString()
+    }
+
+    override fun getGenre(): String {
+        return genres.elementAt(0).toString()
     }
 
     override fun getCover(): String {

--- a/app/src/main/java/ch/epfl/sdp/blindwar/game/util/DisplayableItemAdapter.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindwar/game/util/DisplayableItemAdapter.kt
@@ -91,6 +91,8 @@ class DisplayableItemAdapter(
         /** Playlist info **/
         private val cardView = view.findViewById<ConstraintLayout>(R.id.base_cardview)
         private val name: TextView = view.findViewById(R.id.playlistName)
+        private val difficulty: TextView = view.findViewById(R.id.difficultyLabel)
+        private val genre: TextView = view.findViewById(R.id.genreLabel)
         private val author = view.findViewById<TextView>(R.id.authorTextview)
         private val coverCard = view.findViewById<CardView>(R.id.coverCard)
 
@@ -121,6 +123,8 @@ class DisplayableItemAdapter(
         fun bind(displayed: Displayable) {
             name.text = displayed.getName().uppercase()
             author.text = displayed.getAuthor()
+            difficulty.text = displayed.getLevel()
+            genre.text = displayed.getGenre()
 
             /** Retrieve the playlist cover : image retrieval must be done on another thread
              *  we use runBlocking to avoid this function to be suspendable **/

--- a/app/src/main/java/ch/epfl/sdp/blindwar/game/util/DisplayableItemAdapter.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindwar/game/util/DisplayableItemAdapter.kt
@@ -204,9 +204,7 @@ class DisplayableItemAdapter(
                         val match: Match? = gameInstanceViewModel.createMatch()
                         if (match != null) {
                             val dialog = DynamicLinkHelper.setDynamicLinkDialog(
-                                context.getString(R.string.multi_wait_players),
-                                match.uid,
-                                context
+                                context.getString(R.string.multi_wait_players), match.uid, context
                             )
                             dialog.show()
                             listener = Firebase.firestore.collection(MatchDatabase.COLLECTION_PATH)
@@ -215,9 +213,7 @@ class DisplayableItemAdapter(
                                         return@addSnapshotListener
                                     }
                                     if (SnapshotListener.listenerOnLobby(
-                                            snapshot,
-                                            context,
-                                            dialog
+                                            snapshot, context, dialog
                                         )
                                     ) {
                                         listener?.remove()
@@ -284,9 +280,7 @@ class DisplayableItemAdapter(
                     /** Modify the music preview to not spoil the playlist too much **/
                     if (displayed.extendable()) {
                         AudioHelper.soundAlter(
-                            player,
-                            AudioHelper.HIGH,
-                            AudioHelper.FAST
+                            player, AudioHelper.HIGH, AudioHelper.FAST
                         )
                         duration = DURATION_FAST
                     }

--- a/app/src/main/java/ch/epfl/sdp/blindwar/game/util/GameUtil.kt
+++ b/app/src/main/java/ch/epfl/sdp/blindwar/game/util/GameUtil.kt
@@ -218,7 +218,7 @@ object GameUtil {
         REV_PLAYLIST,
         "",
         URL_PREVIEW_TUTORIAL,
-        Difficulty.EASY
+        Difficulty.DIFFICULT
     )
 
     private val tutorialPlaylist = LocalPlaylist(

--- a/app/src/main/res/layout/playlist_expanded_cardview.xml
+++ b/app/src/main/res/layout/playlist_expanded_cardview.xml
@@ -58,7 +58,8 @@
                     app:layout_constraintVertical_bias="0.0"
                     app:srcCompat="@drawable/baseline_navigate_before_24"
                     app:tint="@color/ivory"
-                    tools:ignore="SpeakableTextPresentCheck" />
+                    tools:ignore="SpeakableTextPresentCheck"
+                    android:contentDescription="@string/button_to_expand_playlist" />
 
                 <ImageButton
                     android:id="@+id/playPreview"
@@ -70,7 +71,8 @@
                     app:layout_constraintStart_toEndOf="@+id/playlistName"
                     app:layout_constraintTop_toTopOf="@+id/progress_preview"
                     app:srcCompat="@drawable/play_arrow_small"
-                    app:tint="@color/ivory" />
+                    app:tint="@color/ivory"
+                    android:contentDescription="@string/button_to_play_preview_of_playlist" />
 
                 <ImageView
                     android:id="@+id/authorIcon"
@@ -83,7 +85,8 @@
                     app:layout_constraintTop_toBottomOf="@+id/playlistName"
                     app:layout_constraintVertical_bias="0.0"
                     app:srcCompat="@drawable/ic_baseline_check_24"
-                    app:tint="@color/ivory" />
+                    app:tint="@color/ivory"
+                    android:contentDescription="@string/the_author_of_this_playlist" />
 
 
                 <TextView
@@ -104,7 +107,7 @@
                     app:layout_constraintStart_toEndOf="@+id/coverGuideline"
                     app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintVertical_bias="1.0"
-                    tools:text="LONG PLAYLIST HAHAH" />
+                    tools:text="LONG PLAYLIST HAHA" />
 
                 <TextView
                     android:id="@+id/authorTextview"
@@ -131,7 +134,7 @@
                     android:layout_marginTop="6dp"
                     android:background="@drawable/hard_label_frame"
                     android:fontFamily="@font/oxygen_light"
-                    android:text="HARD"
+                    android:text="@string/hard"
                     android:textColor="@color/ivory"
                     android:textSize="11sp"
                     app:layout_constraintBottom_toBottomOf="parent"
@@ -150,7 +153,7 @@
                     android:layout_marginTop="6dp"
                     android:background="@drawable/genre_label_frame"
                     android:fontFamily="@font/oxygen_light"
-                    android:text="POP"
+                    android:text="@string/pop"
                     android:textColor="@color/ivory"
                     android:textSize="11sp"
                     app:layout_constraintBottom_toBottomOf="parent"
@@ -276,7 +279,8 @@
                     app:layout_constraintStart_toEndOf="@+id/guideline8"
                     app:layout_constraintTop_toTopOf="parent"
                     app:srcCompat="@drawable/play_arrow"
-                    tools:ignore="SpeakableTextPresentCheck" />
+                    tools:ignore="SpeakableTextPresentCheck"
+                    android:contentDescription="@string/button_to_start_game" />
 
                 <NumberPicker
                     android:id="@+id/roundPicker"
@@ -314,7 +318,7 @@
                     android:layout_marginEnd="8dp"
                     android:autoSizeTextType="uniform"
                     android:fontFamily="@font/oxygen"
-                    android:text="ROUNDS"
+                    android:text="@string/rounds"
                     android:textColor="@color/ivory"
                     app:layout_constraintBottom_toBottomOf="@+id/roundPicker"
                     app:layout_constraintEnd_toStartOf="@+id/timerPicker"
@@ -332,7 +336,7 @@
                     android:layout_marginEnd="8dp"
                     android:autoSizeTextType="uniform"
                     android:fontFamily="@font/oxygen"
-                    android:text="TIMER"
+                    android:text="@string/timer"
                     android:textColor="@color/ivory"
                     app:layout_constraintBottom_toBottomOf="@+id/timerPicker"
                     app:layout_constraintEnd_toStartOf="@+id/guideline8"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -208,4 +208,12 @@
     <string name="share_title">Share invitation</string>
     <string name="share_text">Share BlindWar invitation !</string>
     <string name="share_subject">Invitation link !</string>
+    <string name="button_to_expand_playlist">Button to expand playlist</string>
+    <string name="button_to_play_preview_of_playlist">Button to play preview of playlist</string>
+    <string name="the_author_of_this_playlist">The author of this playlist</string>
+    <string name="hard">HARD</string>
+    <string name="pop">POP</string>
+    <string name="button_to_start_game">Button to start game</string>
+    <string name="rounds">ROUNDS</string>
+    <string name="timer">TIMER</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,6 +214,5 @@
     <string name="hard">HARD</string>
     <string name="pop">POP</string>
     <string name="button_to_start_game">Button to start game</string>
-    <string name="rounds">ROUNDS</string>
     <string name="timer">TIMER</string>
 </resources>

--- a/app/src/test/java/ch/epfl/sdp/blindwar/data/music/metadata/MusicMetadataTest.kt
+++ b/app/src/test/java/ch/epfl/sdp/blindwar/data/music/metadata/MusicMetadataTest.kt
@@ -13,22 +13,71 @@ class MusicMetadataTest : TestCase() {
         assertThat(musicMetaData.toString(), `is`(expected))
     }
 
-    fun testGetTitle() {
+    fun testGetArtist() {
         val expected = "Lady Gaga"
         val musicMetaData = metadataTutorial()["Lady Gaga"]!!
         assertThat(musicMetaData.artist, `is`(expected))
     }
 
-    fun testGetArtist() {
+    fun testGetArtistWithMethod() {
+        val expected = "Lady Gaga"
+        val musicMetaData = metadataTutorial()["Lady Gaga"]!!
+        assertThat(musicMetaData.getAuthor(), `is`(expected))
+    }
+
+    fun testGetTitle() {
         val expected = "Shine On You Crazy Diamond"
         val musicMetaData =
             URIMusicMetadata("Shine On You Crazy Diamond", "Pink Floyd", "", 650000, "URI")
         assertThat(musicMetaData.title, `is`(expected))
     }
 
+    fun testGetTitleWithMethod() {
+        val expected = "Shine On You Crazy Diamond"
+        val musicMetaData =
+            URIMusicMetadata("Shine On You Crazy Diamond", "Pink Floyd", "", 650000, "URI")
+        assertThat(musicMetaData.getName(), `is`(expected))
+    }
+
     fun testGetImageUrl() {
         val expected = "https://i.scdn.co/image/ab67616d0000b273b33d46dfa2635a47eebf63b2"
         val musicMetaData = metadataTutorial()["Daft Punk"]!!
         assertThat(musicMetaData.imageUrl, `is`(expected))
+    }
+
+    fun testGetImageUrlWithMethod() {
+        val expected = "https://i.scdn.co/image/ab67616d0000b273b33d46dfa2635a47eebf63b2"
+        val musicMetaData = metadataTutorial()["Daft Punk"]!!
+        assertThat(musicMetaData.getCover(), `is`(expected))
+    }
+
+    fun testGetLevel() {
+        val expected = ""
+        val musicMetaData = metadataTutorial()["Daft Punk"]!!
+        assertThat(musicMetaData.getLevel(), `is`(expected))
+    }
+
+    fun testGetGenre() {
+        val expected = ""
+        val musicMetaData = metadataTutorial()["Daft Punk"]!!
+        assertThat(musicMetaData.getGenre(), `is`(expected))
+    }
+
+    fun testGetPreviewUrl() {
+        val expected = ""
+        val musicMetaData = metadataTutorial()["Daft Punk"]!!
+        assertThat(musicMetaData.getPreviewUrl(), `is`(expected))
+    }
+
+    fun testGetSize() {
+        val expected = 0
+        val musicMetaData = metadataTutorial()["Daft Punk"]!!
+        assertThat(musicMetaData.getSize(), `is`(expected))
+    }
+
+    fun testExtendable() {
+        val expected = false
+        val musicMetaData = metadataTutorial()["Daft Punk"]!!
+        assertThat(musicMetaData.extendable(), `is`(expected))
     }
 }

--- a/app/src/test/java/ch/epfl/sdp/blindwar/data/playlists/PlaylistTest.kt
+++ b/app/src/test/java/ch/epfl/sdp/blindwar/data/playlists/PlaylistTest.kt
@@ -9,7 +9,7 @@ class PlaylistTest : TestCase() {
         val playlist = Playlist()
         assertTrue(playlist.imageUrl.isEmpty())
         assertTrue(playlist.uid.isEmpty())
-        assertTrue(playlist.difficulty == Difficulty.EASY)
+        assertTrue(playlist.difficulty == null)
         assertTrue(playlist.genres.isEmpty())
         assertTrue(playlist.songs.isEmpty())
     }
@@ -18,7 +18,7 @@ class PlaylistTest : TestCase() {
         val playlist = LocalPlaylist("", "")
         assertTrue(playlist.imageUrl.isEmpty())
         assertTrue(playlist.uid.isEmpty())
-        assertTrue(playlist.difficulty == Difficulty.EASY)
+        assertTrue(playlist.difficulty == null)
         assertTrue(playlist.genres.isEmpty())
         assertTrue(playlist.songs.isEmpty())
     }
@@ -27,7 +27,7 @@ class PlaylistTest : TestCase() {
         val playlist = OnlinePlaylist("", "")
         assertTrue(playlist.imageUrl.isEmpty())
         assertTrue(playlist.uid.isEmpty())
-        assertTrue(playlist.difficulty == Difficulty.EASY)
+        assertTrue(playlist.difficulty == null)
         assertTrue(playlist.genres.isEmpty())
         assertTrue(playlist.songs.isEmpty())
     }


### PR DESCRIPTION
Genre and difficulty in playlists are no longer hardcoded values, but come from the playlists themselves. Playlists are created with null difficulty, which is then overwritten by playlist value. Removed some hardcoded values & added some image descriptors to xml